### PR TITLE
[Setting/#3] Color setting

### DIFF
--- a/UniVoice/UniVoice.xcodeproj/project.pbxproj
+++ b/UniVoice/UniVoice.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		880ED98D2C2403490045A620 /* Differentiator in Frameworks */ = {isa = PBXBuildFile; productRef = 880ED98C2C2403490045A620 /* Differentiator */; };
 		880ED98F2C2403490045A620 /* RxDataSources in Frameworks */ = {isa = PBXBuildFile; productRef = 880ED98E2C2403490045A620 /* RxDataSources */; };
 		8851A2722C2404CA006912D4 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 8851A2712C2404CA006912D4 /* .swiftlint.yml */; };
-		DC3B1A142C317FC9003FA5C9 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3B1A132C317FC9003FA5C9 /* UIColor+.swift */; };
+		DC3B1A162C3182A7003FA5C9 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3B1A152C3182A7003FA5C9 /* UIColor+.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -36,7 +36,7 @@
 		880ED95A2C23F75D0045A620 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		880ED95C2C23F75D0045A620 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8851A2712C2404CA006912D4 /* .swiftlint.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
-		DC3B1A132C317FC9003FA5C9 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
+		DC3B1A152C3182A7003FA5C9 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -177,7 +177,7 @@
 		880ED96C2C23FE460045A620 /* Extension */ = {
 			isa = PBXGroup;
 			children = (
-				DC3B1A132C317FC9003FA5C9 /* UIColor+.swift */,
+				DC3B1A152C3182A7003FA5C9 /* UIColor+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -351,9 +351,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				880ED9532C23F75B0045A620 /* ViewController.swift in Sources */,
+				DC3B1A162C3182A7003FA5C9 /* UIColor+.swift in Sources */,
 				880ED94F2C23F75B0045A620 /* AppDelegate.swift in Sources */,
 				880ED9512C23F75B0045A620 /* SceneDelegate.swift in Sources */,
-				DC3B1A142C317FC9003FA5C9 /* UIColor+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/UniVoice/UniVoice.xcodeproj/project.pbxproj
+++ b/UniVoice/UniVoice.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		880ED98D2C2403490045A620 /* Differentiator in Frameworks */ = {isa = PBXBuildFile; productRef = 880ED98C2C2403490045A620 /* Differentiator */; };
 		880ED98F2C2403490045A620 /* RxDataSources in Frameworks */ = {isa = PBXBuildFile; productRef = 880ED98E2C2403490045A620 /* RxDataSources */; };
 		8851A2722C2404CA006912D4 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 8851A2712C2404CA006912D4 /* .swiftlint.yml */; };
+		DC3B1A142C317FC9003FA5C9 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3B1A132C317FC9003FA5C9 /* UIColor+.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -35,6 +36,7 @@
 		880ED95A2C23F75D0045A620 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		880ED95C2C23F75D0045A620 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8851A2712C2404CA006912D4 /* .swiftlint.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		DC3B1A132C317FC9003FA5C9 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -175,6 +177,7 @@
 		880ED96C2C23FE460045A620 /* Extension */ = {
 			isa = PBXGroup;
 			children = (
+				DC3B1A132C317FC9003FA5C9 /* UIColor+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -350,6 +353,7 @@
 				880ED9532C23F75B0045A620 /* ViewController.swift in Sources */,
 				880ED94F2C23F75B0045A620 /* AppDelegate.swift in Sources */,
 				880ED9512C23F75B0045A620 /* SceneDelegate.swift in Sources */,
+				DC3B1A142C317FC9003FA5C9 /* UIColor+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/UniVoice/UniVoice/Global/Extension/UIColor+.swift
+++ b/UniVoice/UniVoice/Global/Extension/UIColor+.swift
@@ -1,0 +1,17 @@
+//
+//  UIColor+.swift
+//  UniVoice
+//
+//  Created by 오연서 on 6/30/24.
+//
+
+import UIKit
+
+extension UIColor {
+    /// Font Color
+    static let b01 = UIColor(named: "B01")
+    static let b02 = UIColor(named: "B02")
+    static let b03 = UIColor(named: "B03")
+    static let b04 = UIColor(named: "B04")
+    static let w01 = UIColor(named: "W01")
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Font/B01.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Font/B01.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "17",
+          "green" : "17",
+          "red" : "17"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Font/B02.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Font/B02.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "85",
+          "green" : "85",
+          "red" : "85"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Font/B03.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Font/B03.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "118",
+          "green" : "118",
+          "red" : "118"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Font/B04.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Font/B04.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "153",
+          "green" : "153",
+          "red" : "153"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Font/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Font/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Font/W01.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Font/W01.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "255",
+          "green" : "255",
+          "red" : "255"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Line/Black.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Line/Black.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "17",
+          "green" : "17",
+          "red" : "17"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Line/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Line/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Line/Light.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Line/Light.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "245",
+          "green" : "241",
+          "red" : "241"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Line/Regular.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/Line/Regular.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "235",
+          "green" : "229",
+          "red" : "229"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Blue100.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Blue100.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "252",
+          "green" : "232",
+          "red" : "225"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Blue200.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Blue200.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "249",
+          "green" : "208",
+          "red" : "194"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Blue300.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Blue300.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "240",
+          "green" : "103",
+          "red" : "62"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Blue400.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Blue400.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "216",
+          "green" : "93",
+          "red" : "56"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Blue50.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Blue50.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "253",
+          "green" : "240",
+          "red" : "235"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Blue500.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Blue500.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "192",
+          "green" : "82",
+          "red" : "49"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Blue600.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Blue600.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "180",
+          "green" : "77",
+          "red" : "46"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Blue700.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Blue700.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "144",
+          "green" : "61",
+          "red" : "37"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Blue800.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Blue800.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "108",
+          "green" : "46",
+          "red" : "27"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Blue900.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Blue900.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "84",
+          "green" : "36",
+          "red" : "21"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Gray100.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Gray100.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "225",
+          "green" : "225",
+          "red" : "225"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Gray200.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Gray200.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "187",
+          "green" : "187",
+          "red" : "187"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Gray300.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Gray300.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "153",
+          "green" : "153",
+          "red" : "153"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Gray400.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Gray400.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "136",
+          "green" : "136",
+          "red" : "136"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Gray50.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Gray50.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "245",
+          "green" : "241",
+          "red" : "241"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Gray500.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Gray500.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "118",
+          "green" : "118",
+          "red" : "118"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Gray600.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Gray600.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "102",
+          "green" : "102",
+          "red" : "102"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Gray700.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Gray700.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "80",
+          "green" : "80",
+          "red" : "80"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Gray800.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Gray800.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "51",
+          "green" : "51",
+          "red" : "51"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Gray900.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Gray900.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "17",
+          "green" : "17",
+          "red" : "17"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Mint100.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Mint100.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "246",
+          "green" : "250",
+          "red" : "224"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Mint200.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Mint200.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "237",
+          "green" : "244",
+          "red" : "191"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Mint300.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Mint300.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "198",
+          "green" : "222",
+          "red" : "102"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Mint400.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Mint400.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "179",
+          "green" : "200",
+          "red" : "92"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Mint50.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Mint50.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "249",
+          "green" : "251",
+          "red" : "234"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Mint500.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Mint500.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "159",
+          "green" : "177",
+          "red" : "80"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Mint600.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Mint600.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "149",
+          "green" : "166",
+          "red" : "75"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Mint700.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Mint700.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "119",
+          "green" : "133",
+          "red" : "58"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Mint800.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Mint800.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "89",
+          "green" : "99",
+          "red" : "42"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Mint900.colorset/Contents.json
+++ b/UniVoice/UniVoice/Global/Resource/Assets.xcassets/ColorSet/System/Mint900.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "69",
+          "green" : "78",
+          "red" : "31"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## 📌 What is the PR?
- 컬러 에셋 추가

## 🪄 Changes
- 컬러 에셋 추가했습니다

## 🙆🏻 To Reviewers
Assets 파일에 컬러셋을 추가하니, Xcode에서
**static let blue100 = UIColor(named: "Blue100")**
와 같은 코드를 추가하지 않아도 이름을 자동으로(?) 설정해주는 것 같습니다.

이로 인해 UIColor(named: "B01")는 UIColor.B_01 형식으로 작성해야 하는데, 코딩 컨벤션과 맞지 않는 것 같아
관련된 코드만 따로 extension UIColor+에 추가했습니다.

다음과 같이 사용하시면 됩니당:
```swift
mainLabel.textColor = .mint50
mainLabel.textColor = .blue500
mainLabel.textColor = .b01
mainLabel.textColor = .B_01 //이것도 가능
```

## 💭 Related Issues
- Resolved: #3 
