### PR TITLE
[Feat/#72] API 구조 설계 및 초기 세팅

### DIFF
--- a/UniVoice/UniVoice.xcodeproj/project.pbxproj
+++ b/UniVoice/UniVoice.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		211B408A2C3E8424008CFAAD /* StudentInfoInputVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211B40892C3E8424008CFAAD /* StudentInfoInputVM.swift */; };
 		211B408C2C3ED58A008CFAAD /* StudentInfoConfirmVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211B408B2C3ED58A008CFAAD /* StudentInfoConfirmVM.swift */; };
+		212FCAC92C4577BC000E8223 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212FCAC82C4577BC000E8223 /* NetworkResult.swift */; };
 		2132A8382C3A6BA800795667 /* StudentIDPhotoInputVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132A8372C3A6BA800795667 /* StudentIDPhotoInputVC.swift */; };
 		2132A83A2C3A6E2B00795667 /* StudentIDPhotoInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132A8392C3A6E2B00795667 /* StudentIDPhotoInputView.swift */; };
 		2132A83C2C3A6FAD00795667 /* StudentInfoInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132A83B2C3A6FAD00795667 /* StudentInfoInputView.swift */; };
@@ -124,6 +125,7 @@
 /* Begin PBXFileReference section */
 		211B40892C3E8424008CFAAD /* StudentInfoInputVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentInfoInputVM.swift; sourceTree = "<group>"; };
 		211B408B2C3ED58A008CFAAD /* StudentInfoConfirmVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentInfoConfirmVM.swift; sourceTree = "<group>"; };
+		212FCAC82C4577BC000E8223 /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
 		2132A8372C3A6BA800795667 /* StudentIDPhotoInputVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentIDPhotoInputVC.swift; sourceTree = "<group>"; };
 		2132A8392C3A6E2B00795667 /* StudentIDPhotoInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentIDPhotoInputView.swift; sourceTree = "<group>"; };
 		2132A83B2C3A6FAD00795667 /* StudentInfoInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StudentInfoInputView.swift; path = UniVoice/Presentation/SignUpPage/View/StudentInfoInputView.swift; sourceTree = SOURCE_ROOT; };
@@ -374,6 +376,7 @@
 		880ED9682C23FE160045A620 /* Router */ = {
 			isa = PBXGroup;
 			children = (
+				212FCAC82C4577BC000E8223 /* NetworkResult.swift */,
 			);
 			path = Router;
 			sourceTree = "<group>";
@@ -871,6 +874,7 @@
 				2132A8462C3A6FFB00795667 /* StudentInfoInputVC.swift in Sources */,
 				EDE8CA222C37C51300E828F1 /* DepartmentInputView.swift in Sources */,
 				880ED9532C23F75B0045A620 /* ViewController.swift in Sources */,
+				212FCAC92C4577BC000E8223 /* NetworkResult.swift in Sources */,
 				21E15DFE2C3F0637003358A0 /* UIImage+.swift in Sources */,
 				88325C362C38B5C5004A293D /* UINavigationBar+.swift in Sources */,
 				881A3C5B2C3AE6E2003A72E6 /* QuickScanIndicatorView.swift in Sources */,

--- a/UniVoice/UniVoice.xcodeproj/project.pbxproj
+++ b/UniVoice/UniVoice.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		211B408A2C3E8424008CFAAD /* StudentInfoInputVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211B40892C3E8424008CFAAD /* StudentInfoInputVM.swift */; };
 		211B408C2C3ED58A008CFAAD /* StudentInfoConfirmVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211B408B2C3ED58A008CFAAD /* StudentInfoConfirmVM.swift */; };
 		212FCAC92C4577BC000E8223 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212FCAC82C4577BC000E8223 /* NetworkResult.swift */; };
+		212FCACD2C457907000E8223 /* ServiceTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212FCACC2C457907000E8223 /* ServiceTargetType.swift */; };
+		212FCACF2C457916000E8223 /* UserTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212FCACE2C457916000E8223 /* UserTargetType.swift */; };
+		212FCAD12C45796C000E8223 /* NoticeTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212FCAD02C45796C000E8223 /* NoticeTargetType.swift */; };
 		2132A8382C3A6BA800795667 /* StudentIDPhotoInputVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132A8372C3A6BA800795667 /* StudentIDPhotoInputVC.swift */; };
 		2132A83A2C3A6E2B00795667 /* StudentIDPhotoInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132A8392C3A6E2B00795667 /* StudentIDPhotoInputView.swift */; };
 		2132A83C2C3A6FAD00795667 /* StudentInfoInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132A83B2C3A6FAD00795667 /* StudentInfoInputView.swift */; };
@@ -126,6 +129,9 @@
 		211B40892C3E8424008CFAAD /* StudentInfoInputVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentInfoInputVM.swift; sourceTree = "<group>"; };
 		211B408B2C3ED58A008CFAAD /* StudentInfoConfirmVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentInfoConfirmVM.swift; sourceTree = "<group>"; };
 		212FCAC82C4577BC000E8223 /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
+		212FCACC2C457907000E8223 /* ServiceTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceTargetType.swift; sourceTree = "<group>"; };
+		212FCACE2C457916000E8223 /* UserTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTargetType.swift; sourceTree = "<group>"; };
+		212FCAD02C45796C000E8223 /* NoticeTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeTargetType.swift; sourceTree = "<group>"; };
 		2132A8372C3A6BA800795667 /* StudentIDPhotoInputVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentIDPhotoInputVC.swift; sourceTree = "<group>"; };
 		2132A8392C3A6E2B00795667 /* StudentIDPhotoInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentIDPhotoInputView.swift; sourceTree = "<group>"; };
 		2132A83B2C3A6FAD00795667 /* StudentInfoInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StudentInfoInputView.swift; path = UniVoice/Presentation/SignUpPage/View/StudentInfoInputView.swift; sourceTree = SOURCE_ROOT; };
@@ -251,6 +257,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		212FCAD22C45799D000E8223 /* TargetType */ = {
+			isa = PBXGroup;
+			children = (
+				212FCACC2C457907000E8223 /* ServiceTargetType.swift */,
+				212FCACE2C457916000E8223 /* UserTargetType.swift */,
+				212FCAD02C45796C000E8223 /* NoticeTargetType.swift */,
+			);
+			path = TargetType;
+			sourceTree = "<group>";
+		};
 		2195F6DB2C397539008D2485 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
@@ -377,6 +393,7 @@
 			isa = PBXGroup;
 			children = (
 				212FCAC82C4577BC000E8223 /* NetworkResult.swift */,
+				212FCAD22C45799D000E8223 /* TargetType */,
 			);
 			path = Router;
 			sourceTree = "<group>";
@@ -921,6 +938,7 @@
 				21DF05C42C3FCE01005EB117 /* CreateAccountVM.swift in Sources */,
 				EDE8CA242C37C52B00E828F1 /* AdmissionYearSelectionView.swift in Sources */,
 				EDF4C89C2C43F9BD00DE7643 /* TargetInputView.swift in Sources */,
+				212FCACF2C457916000E8223 /* UserTargetType.swift in Sources */,
 				88AB980C2C3F04B300AC5043 /* ChipContentView.swift in Sources */,
 				EDE8CA2C2C37C5E500E828F1 /* AdmissionYearSelectionVC.swift in Sources */,
 				88AB98172C41749D00AC5043 /* QuickScanCompletionView.swift in Sources */,
@@ -928,10 +946,12 @@
 				882DB1652C31D83F00D73FEF /* WelcomeView.swift in Sources */,
 				88AB98082C3ECAB900AC5043 /* QuickScanView.swift in Sources */,
 				DC91FACC2C42B9A70095DD5E /* HeaderView.swift in Sources */,
+				212FCACD2C457907000E8223 /* ServiceTargetType.swift in Sources */,
 				DC33DB102C3B1691008B321E /* MainHomeViewController.swift in Sources */,
 				88AB98102C3FD35300AC5043 /* QuickScanViewModel.swift in Sources */,
 				882DB15D2C31C6D200D73FEF /* LoginViewController.swift in Sources */,
 				DC9EBCB82C3F44FC007337A0 /* MainHomeViewModel.swift in Sources */,
+				212FCAD12C45796C000E8223 /* NoticeTargetType.swift in Sources */,
 				882DB1612C31D38300D73FEF /* InitialView.swift in Sources */,
 				88293F852C43F4680082A986 /* SavedNoticeVM.swift in Sources */,
 				EDF4C8922C41DA6E00DE7643 /* TargetView.swift in Sources */,

--- a/UniVoice/UniVoice.xcodeproj/project.pbxproj
+++ b/UniVoice/UniVoice.xcodeproj/project.pbxproj
@@ -10,9 +10,14 @@
 		211B408A2C3E8424008CFAAD /* StudentInfoInputVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211B40892C3E8424008CFAAD /* StudentInfoInputVM.swift */; };
 		211B408C2C3ED58A008CFAAD /* StudentInfoConfirmVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211B408B2C3ED58A008CFAAD /* StudentInfoConfirmVM.swift */; };
 		212FCAC92C4577BC000E8223 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212FCAC82C4577BC000E8223 /* NetworkResult.swift */; };
-		212FCACD2C457907000E8223 /* ServiceTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212FCACC2C457907000E8223 /* ServiceTargetType.swift */; };
+		212FCACD2C457907000E8223 /* UniVoiceTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212FCACC2C457907000E8223 /* UniVoiceTargetType.swift */; };
 		212FCACF2C457916000E8223 /* UserTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212FCACE2C457916000E8223 /* UserTargetType.swift */; };
 		212FCAD12C45796C000E8223 /* NoticeTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212FCAD02C45796C000E8223 /* NoticeTargetType.swift */; };
+		212FCAD42C458709000E8223 /* ServiceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212FCAD32C458709000E8223 /* ServiceManager.swift */; };
+		212FCAD62C4587BD000E8223 /* MoyaLoggingPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212FCAD52C4587BD000E8223 /* MoyaLoggingPlugin.swift */; };
+		212FCAD92C458CD1000E8223 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212FCAD82C458CD1000E8223 /* Service.swift */; };
+		212FCADB2C45933A000E8223 /* UserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212FCADA2C45933A000E8223 /* UserService.swift */; };
+		212FCADD2C459628000E8223 /* NoticeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212FCADC2C459628000E8223 /* NoticeService.swift */; };
 		2132A8382C3A6BA800795667 /* StudentIDPhotoInputVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132A8372C3A6BA800795667 /* StudentIDPhotoInputVC.swift */; };
 		2132A83A2C3A6E2B00795667 /* StudentIDPhotoInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132A8392C3A6E2B00795667 /* StudentIDPhotoInputView.swift */; };
 		2132A83C2C3A6FAD00795667 /* StudentInfoInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2132A83B2C3A6FAD00795667 /* StudentInfoInputView.swift */; };
@@ -129,9 +134,14 @@
 		211B40892C3E8424008CFAAD /* StudentInfoInputVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentInfoInputVM.swift; sourceTree = "<group>"; };
 		211B408B2C3ED58A008CFAAD /* StudentInfoConfirmVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentInfoConfirmVM.swift; sourceTree = "<group>"; };
 		212FCAC82C4577BC000E8223 /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
-		212FCACC2C457907000E8223 /* ServiceTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceTargetType.swift; sourceTree = "<group>"; };
+		212FCACC2C457907000E8223 /* UniVoiceTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniVoiceTargetType.swift; sourceTree = "<group>"; };
 		212FCACE2C457916000E8223 /* UserTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTargetType.swift; sourceTree = "<group>"; };
 		212FCAD02C45796C000E8223 /* NoticeTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeTargetType.swift; sourceTree = "<group>"; };
+		212FCAD32C458709000E8223 /* ServiceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceManager.swift; sourceTree = "<group>"; };
+		212FCAD52C4587BD000E8223 /* MoyaLoggingPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoyaLoggingPlugin.swift; sourceTree = "<group>"; };
+		212FCAD82C458CD1000E8223 /* Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
+		212FCADA2C45933A000E8223 /* UserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserService.swift; sourceTree = "<group>"; };
+		212FCADC2C459628000E8223 /* NoticeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeService.swift; sourceTree = "<group>"; };
 		2132A8372C3A6BA800795667 /* StudentIDPhotoInputVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentIDPhotoInputVC.swift; sourceTree = "<group>"; };
 		2132A8392C3A6E2B00795667 /* StudentIDPhotoInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentIDPhotoInputView.swift; sourceTree = "<group>"; };
 		2132A83B2C3A6FAD00795667 /* StudentInfoInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StudentInfoInputView.swift; path = UniVoice/Presentation/SignUpPage/View/StudentInfoInputView.swift; sourceTree = SOURCE_ROOT; };
@@ -260,11 +270,22 @@
 		212FCAD22C45799D000E8223 /* TargetType */ = {
 			isa = PBXGroup;
 			children = (
-				212FCACC2C457907000E8223 /* ServiceTargetType.swift */,
+				212FCACC2C457907000E8223 /* UniVoiceTargetType.swift */,
 				212FCACE2C457916000E8223 /* UserTargetType.swift */,
 				212FCAD02C45796C000E8223 /* NoticeTargetType.swift */,
 			);
 			path = TargetType;
+			sourceTree = "<group>";
+		};
+		212FCAD72C458C5D000E8223 /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				212FCAD32C458709000E8223 /* ServiceManager.swift */,
+				212FCAD82C458CD1000E8223 /* Service.swift */,
+				212FCADA2C45933A000E8223 /* UserService.swift */,
+				212FCADC2C459628000E8223 /* NoticeService.swift */,
+			);
+			path = Service;
 			sourceTree = "<group>";
 		};
 		2195F6DB2C397539008D2485 /* ViewModel */ = {
@@ -392,7 +413,9 @@
 		880ED9682C23FE160045A620 /* Router */ = {
 			isa = PBXGroup;
 			children = (
+				212FCAD52C4587BD000E8223 /* MoyaLoggingPlugin.swift */,
 				212FCAC82C4577BC000E8223 /* NetworkResult.swift */,
+				212FCAD72C458C5D000E8223 /* Service */,
 				212FCAD22C45799D000E8223 /* TargetType */,
 			);
 			path = Router;
@@ -889,6 +912,7 @@
 				2132A84E2C3A702400795667 /* SignUpInfoCheckingVC.swift in Sources */,
 				88293F832C43C1370082A986 /* SavedNoticeVC.swift in Sources */,
 				2132A8462C3A6FFB00795667 /* StudentInfoInputVC.swift in Sources */,
+				212FCADD2C459628000E8223 /* NoticeService.swift in Sources */,
 				EDE8CA222C37C51300E828F1 /* DepartmentInputView.swift in Sources */,
 				880ED9532C23F75B0045A620 /* ViewController.swift in Sources */,
 				212FCAC92C4577BC000E8223 /* NetworkResult.swift in Sources */,
@@ -915,6 +939,7 @@
 				DC91FACF2C42E4710095DD5E /* TabBarVC.swift in Sources */,
 				EDE8CA282C37C59800E828F1 /* UniversityInputVC.swift in Sources */,
 				21F7B15E2C3473C500A082D8 /* UILabel+.swift in Sources */,
+				212FCAD62C4587BD000E8223 /* MoyaLoggingPlugin.swift in Sources */,
 				DC91FAD22C42E75D0095DD5E /* AppTab.swift in Sources */,
 				21F7B15A2C34620A00A082D8 /* UIFont+.swift in Sources */,
 				883B2CFD2C42B6E400D19A78 /* NoAccountView.swift in Sources */,
@@ -929,6 +954,7 @@
 				2132A8422C3A6FD400795667 /* CreateAccountView.swift in Sources */,
 				2132A83E2C3A6FC000795667 /* StudentInfoConfirmView.swift in Sources */,
 				88AB98192C418A2000AC5043 /* QuickScanCompletionViewController.swift in Sources */,
+				212FCAD92C458CD1000E8223 /* Service.swift in Sources */,
 				88AB980E2C3F27A300AC5043 /* QuickScanViewController.swift in Sources */,
 				EDE8CA2E2C37C5FA00E828F1 /* UnivInfoConfirmVC.swift in Sources */,
 				211B408C2C3ED58A008CFAAD /* StudentInfoConfirmVM.swift in Sources */,
@@ -946,12 +972,13 @@
 				882DB1652C31D83F00D73FEF /* WelcomeView.swift in Sources */,
 				88AB98082C3ECAB900AC5043 /* QuickScanView.swift in Sources */,
 				DC91FACC2C42B9A70095DD5E /* HeaderView.swift in Sources */,
-				212FCACD2C457907000E8223 /* ServiceTargetType.swift in Sources */,
+				212FCACD2C457907000E8223 /* UniVoiceTargetType.swift in Sources */,
 				DC33DB102C3B1691008B321E /* MainHomeViewController.swift in Sources */,
 				88AB98102C3FD35300AC5043 /* QuickScanViewModel.swift in Sources */,
 				882DB15D2C31C6D200D73FEF /* LoginViewController.swift in Sources */,
 				DC9EBCB82C3F44FC007337A0 /* MainHomeViewModel.swift in Sources */,
 				212FCAD12C45796C000E8223 /* NoticeTargetType.swift in Sources */,
+				212FCAD42C458709000E8223 /* ServiceManager.swift in Sources */,
 				882DB1612C31D38300D73FEF /* InitialView.swift in Sources */,
 				88293F852C43F4680082A986 /* SavedNoticeVM.swift in Sources */,
 				EDF4C8922C41DA6E00DE7643 /* TargetView.swift in Sources */,
@@ -966,6 +993,7 @@
 				88AB980A2C3EF48F00AC5043 /* CapsuleLabelView.swift in Sources */,
 				DC33DB172C3B2A64008B321E /* QuickScanCollectionViewCell.swift in Sources */,
 				88AB98152C3FDB2F00AC5043 /* Date+.swift in Sources */,
+				212FCADB2C45933A000E8223 /* UserService.swift in Sources */,
 				DC33DAF92C39CD1F008B321E /* MainHomeView.swift in Sources */,
 				DC9EBCB02C3EB2CC007337A0 /* mainHomeModel.swift in Sources */,
 				DC33DB172C3B2A64008B321E /* QuickScanCollectionViewCell.swift in Sources */,

--- a/UniVoice/UniVoice/Data/Router/MoyaLoggingPlugin.swift
+++ b/UniVoice/UniVoice/Data/Router/MoyaLoggingPlugin.swift
@@ -1,5 +1,5 @@
 //
-//  ServiceTargetType.swift
+//  MoyaLoggingPlugin.swift
 //  UniVoice
 //
 //  Created by 왕정빈 on 7/16/24.
@@ -8,4 +8,6 @@
 import Foundation
 import Moya
 
-protocol ServiceTargetType: TargetType {}
+final class MoyaLoggingPlugin: PluginType {
+    
+}

--- a/UniVoice/UniVoice/Data/Router/NetworkResult.swift
+++ b/UniVoice/UniVoice/Data/Router/NetworkResult.swift
@@ -1,0 +1,17 @@
+//
+//  NetworkResult.swift
+//  UniVoice
+//
+//  Created by 왕정빈 on 7/16/24.
+//
+
+import Foundation
+
+enum NetworkResult<T> {
+    case success(T)
+    case requestErr
+    case decodedErr
+    case pathErr
+    case serverErr
+    case networkFail
+}

--- a/UniVoice/UniVoice/Data/Router/Service/NoticeService.swift
+++ b/UniVoice/UniVoice/Data/Router/Service/NoticeService.swift
@@ -1,0 +1,17 @@
+//
+//  NoticeService.swift
+//  UniVoice
+//
+//  Created by 왕정빈 on 7/16/24.
+//
+
+import Foundation
+import Moya
+import RxSwift
+import RxMoya
+
+extension Service {
+//    func getUniversitList() -> Single<University> {
+//        return userService.provider.rx.request(<#T##token: UserTargetType##UserTargetType#>)
+//    }
+}

--- a/UniVoice/UniVoice/Data/Router/Service/Service.swift
+++ b/UniVoice/UniVoice/Data/Router/Service/Service.swift
@@ -1,0 +1,18 @@
+//
+//  Service.swift
+//  UniVoice
+//
+//  Created by 왕정빈 on 7/16/24.
+//
+
+import Foundation
+import Moya
+
+final class Service {
+    static let shared = Service()
+    
+    let userService = ServiceManager<UserTargetType>()
+    let noticeService = ServiceManager<NoticeTargetType>()
+    
+    private init() {}
+}

--- a/UniVoice/UniVoice/Data/Router/Service/ServiceManager.swift
+++ b/UniVoice/UniVoice/Data/Router/Service/ServiceManager.swift
@@ -1,0 +1,15 @@
+//
+//  ServiceManager.swift
+//  UniVoice
+//
+//  Created by 왕정빈 on 7/16/24.
+//
+
+import Foundation
+import Moya
+
+final class ServiceManager<T: UniVoiceTargetType> {
+    let provider = MoyaProvider<T>(plugins: [MoyaLoggingPlugin()])
+    
+    init() {}
+}

--- a/UniVoice/UniVoice/Data/Router/Service/UserService.swift
+++ b/UniVoice/UniVoice/Data/Router/Service/UserService.swift
@@ -1,0 +1,17 @@
+//
+//  UserService.swift
+//  UniVoice
+//
+//  Created by 왕정빈 on 7/16/24.
+//
+
+import Foundation
+import Moya
+import RxSwift
+import RxMoya
+
+extension Service {
+//    func getUniversityList() -> Single<University> {
+//        return userService.provider.rx.request(<#T##token: UserTargetType##UserTargetType#>)
+//    }
+}

--- a/UniVoice/UniVoice/Data/Router/TargetType/NoticeTargetType.swift
+++ b/UniVoice/UniVoice/Data/Router/TargetType/NoticeTargetType.swift
@@ -12,7 +12,7 @@ enum NoticeTargetType {
     
 }
 
-extension NoticeTargetType: ServiceTargetType {
+extension NoticeTargetType: UniVoiceTargetType {
     var baseURL: URL {
         return URL(string: "test")!
     }

--- a/UniVoice/UniVoice/Data/Router/TargetType/NoticeTargetType.swift
+++ b/UniVoice/UniVoice/Data/Router/TargetType/NoticeTargetType.swift
@@ -1,0 +1,35 @@
+//
+//  NoticeTargetType.swift
+//  UniVoice
+//
+//  Created by 왕정빈 on 7/16/24.
+//
+
+import Foundation
+import Moya
+
+enum NoticeTargetType {
+    
+}
+
+extension NoticeTargetType: ServiceTargetType {
+    var baseURL: URL {
+        return URL(string: "test")!
+    }
+    
+    var path: String {
+        return "test"
+    }
+    
+    var method: Moya.Method {
+        return .get
+    }
+    
+    var task: Moya.Task {
+        return .requestPlain
+    }
+    
+    var headers: [String : String]? {
+        return ["Content-Type": "application/json"]
+    }
+}

--- a/UniVoice/UniVoice/Data/Router/TargetType/ServiceTargetType.swift
+++ b/UniVoice/UniVoice/Data/Router/TargetType/ServiceTargetType.swift
@@ -1,0 +1,11 @@
+//
+//  ServiceTargetType.swift
+//  UniVoice
+//
+//  Created by 왕정빈 on 7/16/24.
+//
+
+import Foundation
+import Moya
+
+protocol ServiceTargetType: TargetType {}

--- a/UniVoice/UniVoice/Data/Router/TargetType/UniVoiceTargetType.swift
+++ b/UniVoice/UniVoice/Data/Router/TargetType/UniVoiceTargetType.swift
@@ -1,0 +1,11 @@
+//
+//  ServiceTargetType.swift
+//  UniVoice
+//
+//  Created by 왕정빈 on 7/16/24.
+//
+
+import Foundation
+import Moya
+
+protocol UniVoiceTargetType: TargetType {}

--- a/UniVoice/UniVoice/Data/Router/TargetType/UserTargetType.swift
+++ b/UniVoice/UniVoice/Data/Router/TargetType/UserTargetType.swift
@@ -1,0 +1,35 @@
+//
+//  UserTargetType.swift
+//  UniVoice
+//
+//  Created by 왕정빈 on 7/16/24.
+//
+
+import Foundation
+import Moya
+
+enum UserTargetType {
+    
+}
+
+extension UserTargetType: ServiceTargetType {
+    var baseURL: URL {
+        return URL(string: "test")!
+    }
+    
+    var path: String {
+        return "test"
+    }
+    
+    var method: Moya.Method {
+        return .get
+    }
+    
+    var task: Moya.Task {
+        return .requestPlain
+    }
+    
+    var headers: [String : String]? {
+        return ["Content-Type": "application/json"]
+    }
+}

--- a/UniVoice/UniVoice/Data/Router/TargetType/UserTargetType.swift
+++ b/UniVoice/UniVoice/Data/Router/TargetType/UserTargetType.swift
@@ -12,7 +12,7 @@ enum UserTargetType {
     
 }
 
-extension UserTargetType: ServiceTargetType {
+extension UserTargetType: UniVoiceTargetType {
     var baseURL: URL {
         return URL(string: "test")!
     }


### PR DESCRIPTION
## 📌 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
API 구조 설계 및 초기 세팅

## 🪄 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- Moya로 네트워크 통신을 하기 위한 TargetType과 Service 설정

## 🌐 Common Changes
<!-- 공통 작업 부분에 대한 수정 사항이 있다면 적어주세요 -->
- Data의 Router 폴더에 각 파일들을 생성

## 📸 Screenshot
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    기능    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/7c6722ad-ffb4-4fee-b455-88fcf0542d21" width ="250">|


## 🙆🏻 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
### API 구조 설계
현재 저희의 남은 시간과 작업량을 고려해봤을 때 각각 API를 만들어서 붙이는 것이 아닌 한명이 전체적으로 API를 설계하고 구현해서 팀원들이 각자 필요한 API 함수를 호출만 해서 View에 데이터를 바인딩할 수 있게 하는게 효율적이고 시간 내에 주어진 할당량을 해낼 수 있다고 생각했습니다

이를 위해서 리드와 상의를 했을 때 두가지 방법을 생각해냈습니다.
1.  각각의 ViewModel에 각자 필요한 API를 구현해주기
2. 싱글톤 패턴을 활용하여 한곳에서 모든 API를 구현하고 다른 팀원들은 가져다 쓰기

이중 **첫번째 방법은 제가 다른 팀원들이 만든 각 View에서 필요한 API를 정확히 파악할 수 없고, 같은 파일에서 작업하다가 충돌의 위험성이 있기**에
두번째 방법으로 결정했습니다.

싱글톤 패턴의 특성상, 싱글톤 프로퍼티를 한번 생성하면 끝까지 메모리에서 해제가 되지 않습니다.
현재 저희의 네트워크 통신 Service는 크게 **회원가입**과 **공지사항** 두개가 있습니다.
유니보이스 앱 특성상 회원가입를 위한 네트워크 통신은 초기에만 사용되고 회원가입이 완료된 이후에는 쓰이지 않기에 각각의 Service를 위한 싱글톤 프로퍼티를 생성하는 것은 메모리 효율이 좋지 않다고 생각하여 하나의 싱글톤 프로퍼티를 생성하고 그 싱글톤을 활용하여 모든 Service를 처리하기로 생각했습니다.



### TargetType
Moya Service에서 각각의 Service의 TargetType에 대해 분기처리를 해줄 수 있게 하기 위해 TargetType를 상속받는 UniVoiceTargetType라는 protocol를 만들었습니다.
이후 각각의 Service에 해당하는 UserTargetType, NoticeTargetType을 생성하여 UniVoiceTargetType를 상속받게하여 endpoint를 작성할 수 있게 하였습니다.

### Service
하나의 싱글톤 프로퍼티로 여러 Service를 처리해주기 위해 다음과 같이 제네릭을 활용하여(`<T: UniVoiceTargetType>`) UniVoiceTargetType를 상속받는 TargetType은 싱글톤 프로퍼티를 사용할 수 있게 하였습니다
제네릭 클래스 안에는 static를 활용한 전역 변수를 만들 수 없기에 `class ServiceManager<T: UniVoiceTargetType>`안에는 
`let provider = MoyaProvider<T>(plugins: [MoyaLoggingPlugin()])`만 생성해두고 Service 파일을 만들어 Service라는 클래스 안에 `static let shared = Service()`라는 싱글톤 프로퍼티를 생성했습니다.
그리고 UserService, NoticeService라는 파일을 만든 후 Service 클래스를 extension하여 각각의 Service에 맞게 파일을 구분할 수 있게 하였습니다


### 사용 방법(ex. UserService의 대학 이름 가져오기 API)
싱글톤 패턴을 사용했기에 사용 방법은 간단합니다
각자의 파일 내에서 따로 프로퍼티를 생성할 필요없이
`Service.shared.(필요한 API 호출 함수 이름)` (ex. `Service.shared.getUniversityList()`)
다음과 같은 코드로 필요한 API를 호출하면 됩니다.

아마 저희는 RxMoya를 사용할 예정이기에 다음과 같이 사용하면 될 것입니다.
```Swift
Service.shared.getUniversityList()
   .subscribe
```


## 💭 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #72 
