### PR TITLE
[Refactor/#188] QuickScanPage 리팩토링

### DIFF
--- a/UniVoice/UniVoice/Presentation/QuickScanPage/View/Cell/QuickScanContentCVC.swift
+++ b/UniVoice/UniVoice/Presentation/QuickScanPage/View/Cell/QuickScanContentCVC.swift
@@ -171,8 +171,6 @@ extension QuickScanContentCVC {
         viewCountLabel.text = "\(cellModel.viewCount)회"
         noticeTitleLabel.text = cellModel.noticeTitle
         
-        contentStackView.arrangedSubviews.forEach { $0.removeFromSuperview() } // 셀 초기화 작업
-        
         let contents = [
             cellModel.noticeTarget,
             Date().getDurationText(from: cellModel.startTime, to: cellModel.endTime),
@@ -233,5 +231,7 @@ extension QuickScanContentCVC {
     override func prepareForReuse() {
         super.prepareForReuse()
         self.disposeBag = DisposeBag()
+        self.contentStackView.arrangedSubviews.forEach { $0.removeFromSuperview() } // 스택뷰 초기화
+        profileImageView.image = nil
     }
 }

--- a/UniVoice/UniVoice/Presentation/QuickScanPage/ViewModel/QuickScanVM.swift
+++ b/UniVoice/UniVoice/Presentation/QuickScanPage/ViewModel/QuickScanVM.swift
@@ -13,7 +13,7 @@ final class QuickScanVM: ViewModelType {
     
     init(id: Int) {
         // API 로직 수행
-        self.getQuickScans(id: id)
+        self.getQuickScans_MOCK(id: id)
             .bind(to: quickScans)
             .disposed(by: disposeBag)
         
@@ -24,7 +24,7 @@ final class QuickScanVM: ViewModelType {
             .subscribe(onNext: { [weak self] scans in
                 guard let self = self else { return }
                 let id = scans[0].noticeId
-                self.postQuickScanCompleted(noticeId: id)
+                // self.postQuickScanCompleted(noticeId: id) // post 해제
             })
             .disposed(by: disposeBag)
     }
@@ -173,5 +173,12 @@ private extension QuickScanVM {
                 }
             }
             .disposed(by: disposeBag)
+    }
+}
+
+// MARK: Temp Mock Data
+extension QuickScanVM {
+    private func getQuickScans_MOCK(id: Int) -> Observable<[QuickScan]> {
+        return .just(QuickScan.dummyData)
     }
 }

--- a/UniVoice/UniVoice/Presentation/QuickScanPage/ViewModel/QuickScanVM.swift
+++ b/UniVoice/UniVoice/Presentation/QuickScanPage/ViewModel/QuickScanVM.swift
@@ -18,15 +18,15 @@ final class QuickScanVM: ViewModelType {
             .disposed(by: disposeBag)
         
         // 초기 진입 시 0번 인덱스 POST 호출
-        quickScans
-            .filter { !$0.isEmpty }
-            .take(1)
-            .subscribe(onNext: { [weak self] scans in
-                guard let self = self else { return }
-                let id = scans[0].noticeId
-                // self.postQuickScanCompleted(noticeId: id) // post 해제
-            })
-            .disposed(by: disposeBag)
+    //        quickScans
+    //            .filter { !$0.isEmpty }
+    //            .take(1)
+    //            .subscribe(onNext: { [weak self] scans in
+    //                guard let self = self else { return }
+    //                let id = scans[0].noticeId
+    //                self.postQuickScanCompleted(noticeId: id)
+    //            })
+    //            .disposed(by: disposeBag)
     }
     
     struct Input {
@@ -41,10 +41,6 @@ final class QuickScanVM: ViewModelType {
         let quickScans: Driver<[QuickScan]>
         /// 현재 페이지 인덱스 스트림
         let currentIndex: Driver<Int>
-        /// 북마크 결과 스트림
-        let bookmarkResult: Driver<Bool>
-        /// 퀵스캔 확인 완료 상태 스트림
-        let viewComplete: Driver<Bool>
     }
     
     var disposeBag = DisposeBag()
@@ -55,8 +51,6 @@ final class QuickScanVM: ViewModelType {
     private let currentIndex = BehaviorRelay(value: 0)
     /// 북마크 결과를 관리하는 PublishRelay
     private let bookmarkResult = PublishRelay<Bool>()
-    /// 퀵스캔 확인 완료 상태를 관리하는 PublishRelay
-    private let viewComplete = PublishRelay<Bool>()
     
     func transform(input: Input) -> Output {
         
@@ -88,8 +82,6 @@ final class QuickScanVM: ViewModelType {
             })
             .disposed(by: disposeBag)
         
-        let currentIndex = input.changeIndex
-        
         // 페이지 인덱스 변경 시 POST 요청 수행
         currentIndex
             .withLatestFrom(quickScans) { (index, scans) in
@@ -107,9 +99,7 @@ final class QuickScanVM: ViewModelType {
         
         return Output(
             quickScans: quickScans.asDriver(),
-            currentIndex: currentIndex.asDriver(onErrorJustReturn: 0),
-            bookmarkResult: bookmarkResult.asDriver(onErrorJustReturn: false),
-            viewComplete: viewComplete.asDriver(onErrorJustReturn: false)
+            currentIndex: currentIndex.asDriver(onErrorJustReturn: 0)
         )
     }
 }


### PR DESCRIPTION
## 📌 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
QuickScanPage(VC-VM, QuickScanContentCVC, QuickScanIndicatorView)
의 로직을 리팩토링했습니다.

## 🪄 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- QuickScanVC-VM 리팩토링
- QuickScan 컴포넌트 - QuickScanContentCVC 리팩토링

## 🙆🏻 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
기존 QuickScanVC의 RxDataSource를 VM으로 이전하는 과정에서 
View + View의 interaction과 연결되는 영역이 많은 RxDataSource의 경우라고 판단되어
옮기지 않았습니다. 좀 더 고민해보고, 필요한 경우 다시 작업해보겠습니다.

POST 관련 API는 어떻게 mock 처리하면 좋을까요?

## 💭 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #188
